### PR TITLE
Improved comments when setting the max text view height

### DIFF
--- a/InputBarAccessoryView/Views/InputBarAccessoryView.swift
+++ b/InputBarAccessoryView/Views/InputBarAccessoryView.swift
@@ -216,10 +216,13 @@ open class InputBarAccessoryView: UIView {
     /// The default value is `FALSE`
     public private(set) var shouldForceTextViewMaxHeight = false
     
-    /// A boolean that determines if the `maxTextViewHeight` should be auto updated on device rotation
+    /// A boolean that determines if the `maxTextViewHeight` should be maintained automatically.
+    /// To control the maximum height of the view yourself, set this to `false`.
     open var shouldAutoUpdateMaxTextViewHeight = true
-    
-    /// The maximum height that the InputTextView can reach. Automatically set with `calculateMaxTextViewHeight()`
+
+    /// The maximum height that the InputTextView can reach.
+    /// This is set automatically when `shouldAutoUpdateMaxTextViewHeight` is true.
+    /// To control the height yourself, make sure to set `shouldAutoUpdateMaxTextViewHeight` to false.
     open var maxTextViewHeight: CGFloat = 0 {
         didSet {
             textViewHeightAnchor?.constant = maxTextViewHeight


### PR DESCRIPTION
I have altered the comments to make it clear how to set the max height yourself and that it is set automatically when `shouldAutoUpdateMaxTextViewHeight` is true.