### PR TITLE
Remove Call to layoutSubviews()

### DIFF
--- a/InputBarAccessoryView/Plugins/AutocompleteManager/Views/AutocompleteCell.swift
+++ b/InputBarAccessoryView/Plugins/AutocompleteManager/Views/AutocompleteCell.swift
@@ -38,7 +38,7 @@ open class AutocompleteCell: UITableViewCell {
     /// A boarder line anchored to the top of the view
     public let separatorLine = SeparatorLine()
     
-    open var imageViewEdgeInsets: UIEdgeInsets = .zero { didSet { layoutSubviews() } }
+    open var imageViewEdgeInsets: UIEdgeInsets = .zero { didSet { setNeedsLayout() } }
     
     // MARK: - Initialization
     


### PR DESCRIPTION
layoutSubviews() should not be called directly.  This was causing issues with autocomplete images resizing when an image inset was used.