### PR TITLE
Added a delegate call to notify when the osOverMax flag has changed.

### DIFF
--- a/InputBarAccessoryView/InputBarAccessoryView.swift
+++ b/InputBarAccessoryView/InputBarAccessoryView.swift
@@ -250,7 +250,11 @@ open class InputBarAccessoryView: UIView {
     
     /// A boolean that indicates if the maxTextViewHeight has been met. Keeping track of this
     /// improves the performance
-    public private(set) var isOverMaxTextViewHeight = false
+    public private(set) var isOverMaxTextViewHeight = false {
+        didSet {
+            delegate?.inputBar(self, didReachMaxTextViewHeight: isOverMaxTextViewHeight)
+        }
+    }
     
     /// A boolean that when set as `TRUE` will always enable the `InputTextView` to be anchored to the
     /// height of `maxTextViewHeight`

--- a/InputBarAccessoryView/Protocols/InputBarAccessoryViewDelegate.swift
+++ b/InputBarAccessoryView/Protocols/InputBarAccessoryViewDelegate.swift
@@ -60,6 +60,13 @@ public protocol InputBarAccessoryViewDelegate: AnyObject {
     ///   - inputBar: The InputBarAccessoryView
     ///   - gesture: The gesture that was recognized
     func inputBar(_ inputBar: InputBarAccessoryView, didSwipeTextViewWith gesture: UISwipeGestureRecognizer)
+
+    /// Called when isOverMaxTextViewHeight is changed
+    ///
+    /// - Parameters:
+    ///   - inputBar: The InputBarAccessoryView
+    ///   - isOverMaxTextViewHeight: The current isOverMaxTextViewHeight value
+    func inputBar(_ inputBar: InputBarAccessoryView, didReachMaxTextViewHeight isOverMaxTextViewHeight: Bool)
 }
 
 public extension InputBarAccessoryViewDelegate {
@@ -71,4 +78,6 @@ public extension InputBarAccessoryViewDelegate {
     func inputBar(_ inputBar: InputBarAccessoryView, textViewTextDidChangeTo text: String) {}
     
     func inputBar(_ inputBar: InputBarAccessoryView, didSwipeTextViewWith gesture: UISwipeGestureRecognizer) {}
+    
+    func inputBar(_ inputBar: InputBarAccessoryView, didReachMaxTextViewHeight isOverMaxTextViewHeight: Bool) {}
 }


### PR DESCRIPTION
I added this to be notified when the text entry was over the max height limit.  This allowed me to perform actions in the delegate implementation as needed.  In particular, I'm hiding the expand button when the there is a lot of text.