### PR TITLE
Fixes accessibility of HorizontalEdgePadding initializers and a typo in its filename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - 5.0.0
     - Swift 5 support
+    - Fixes accessibility of HorizontalEdgePadding initializers and a typo in its filename
 - 4.2.2
     - Fix image paste orientation in `InputTextView`
 - 4.2.1 

--- a/InputBarAccessoryView.xcodeproj/project.pbxproj
+++ b/InputBarAccessoryView.xcodeproj/project.pbxproj
@@ -37,7 +37,7 @@
 		38C867831F50A6AD00811974 /* InputBarButtonItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38C8677B1F50A6AD00811974 /* InputBarButtonItem.swift */; };
 		38C867841F50A6AD00811974 /* InputTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38C8677C1F50A6AD00811974 /* InputTextView.swift */; };
 		38D29FE91F97CBA400E59362 /* InputPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38D29FE81F97CBA400E59362 /* InputPlugin.swift */; };
-		38E0565D2193A5A400EC04FA /* HorizontalEdgeInsets.swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38E0565C2193A5A400EC04FA /* HorizontalEdgeInsets.swift.swift */; };
+		38E0565D2193A5A400EC04FA /* HorizontalEdgeInsets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38E0565C2193A5A400EC04FA /* HorizontalEdgeInsets.swift */; };
 		38ECDBBD219B46D50076E154 /* InputBarViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38ECDBBC219B46D50076E154 /* InputBarViewController.swift */; };
 		38ECDBBF219B46E80076E154 /* RxInputBarAccessoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38ECDBBE219B46E80076E154 /* RxInputBarAccessoryView.swift */; };
 		38F0C1F220C7807D00FF8DD3 /* AutocompleteSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38F0C1F120C7807D00FF8DD3 /* AutocompleteSession.swift */; };
@@ -78,7 +78,7 @@
 		38C8677B1F50A6AD00811974 /* InputBarButtonItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InputBarButtonItem.swift; sourceTree = "<group>"; };
 		38C8677C1F50A6AD00811974 /* InputTextView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InputTextView.swift; sourceTree = "<group>"; };
 		38D29FE81F97CBA400E59362 /* InputPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = InputPlugin.swift; path = InputBarAccessoryView/Protocols/InputPlugin.swift; sourceTree = SOURCE_ROOT; };
-		38E0565C2193A5A400EC04FA /* HorizontalEdgeInsets.swift.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HorizontalEdgeInsets.swift.swift; sourceTree = "<group>"; };
+		38E0565C2193A5A400EC04FA /* HorizontalEdgeInsets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HorizontalEdgeInsets.swift; sourceTree = "<group>"; };
 		38ECDBBC219B46D50076E154 /* InputBarViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputBarViewController.swift; sourceTree = "<group>"; };
 		38ECDBBE219B46E80076E154 /* RxInputBarAccessoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RxInputBarAccessoryView.swift; sourceTree = "<group>"; };
 		38F0C1F120C7807D00FF8DD3 /* AutocompleteSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutocompleteSession.swift; sourceTree = "<group>"; };
@@ -221,7 +221,7 @@
 			isa = PBXGroup;
 			children = (
 				38C867721F50A6AD00811974 /* NSConstraintLayoutSet.swift */,
-				38E0565C2193A5A400EC04FA /* HorizontalEdgeInsets.swift.swift */,
+				38E0565C2193A5A400EC04FA /* HorizontalEdgeInsets.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -379,7 +379,7 @@
 				3821ADDC20F531A600DE0D1D /* KeyboardEvent.swift in Sources */,
 				3876DA921F83551400C89326 /* AutocompleteManager.swift in Sources */,
 				38ECDBBD219B46D50076E154 /* InputBarViewController.swift in Sources */,
-				38E0565D2193A5A400EC04FA /* HorizontalEdgeInsets.swift.swift in Sources */,
+				38E0565D2193A5A400EC04FA /* HorizontalEdgeInsets.swift in Sources */,
 				38C867841F50A6AD00811974 /* InputTextView.swift in Sources */,
 				3876DA901F83530900C89326 /* AutocompleteManagerDataSource.swift in Sources */,
 				3876DAA91F84C0DB00C89326 /* AttachmentsView.swift in Sources */,

--- a/InputBarAccessoryView/Models/HorizontalEdgeInsets.swift
+++ b/InputBarAccessoryView/Models/HorizontalEdgeInsets.swift
@@ -12,5 +12,10 @@ public struct HorizontalEdgePadding {
     public let left: CGFloat
     public let right: CGFloat
 
-    static let zero = HorizontalEdgePadding(left: 0, right: 0)
+    public static let zero = HorizontalEdgePadding(left: 0, right: 0)
+
+    public init(left: CGFloat, right: CGFloat) {
+        self.left = left
+        self.right = right
+    }
 }


### PR DESCRIPTION
* Renames `HorizontalEdgeInsets.swift.swift` to `HorizontalEdgeInsets.swift`
* Exposes the initializer and `zero` property of `HorizontalEdgeInsets`

**Justification per the Swift manual:**

> Default Memberwise Initializers for Structure Types
> The default memberwise initializer for a structure type is considered private if any of the structure’s stored properties are private. Likewise, if any of the structure’s stored properties are file private, the initializer is file private. **Otherwise, the initializer has an access level of internal**.
> 
> As with the default initializer above, if you want a public structure type to be initializable with a memberwise initializer when used in another module, you must provide a public memberwise initializer yourself as part of the type’s definition.
> 

Source: https://docs.swift.org/swift-book/LanguageGuide/AccessControl.html#//apple_ref/doc/uid/TP40014097-CH41-ID3

**Justification for users:**

`open var frameInsets: HorizontalEdgePadding = .zero` in `InputBarAccessoryView.swift:178`.

I am using this property to adjust the input bar view to fit in the detail screen of a `UISplitViewController` as messages on iPad does, therefore I need to use `HorizontalEdgePadding` to use that property. Thank you for including it.

In the current version you will get `initializer is inaccessible due to 'internal' protection level` if you try to use `HorizontalEdgePadding`. You can also not change the default's .zero values as they are let constants.