### PR TITLE
Improved support for custom middle content views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - 4.3.0
     - Swift 5 support
     - Fixes accessibility of HorizontalEdgePadding initializers and a typo in its filename
+    - Improves support for custom middle content views (see example of a Messages.app 'Subject + Message' implementation)
 - 4.2.2
     - Fix image paste orientation in `InputTextView`
 - 4.2.1 

--- a/InputBarAccessoryView.xcodeproj/project.pbxproj
+++ b/InputBarAccessoryView.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		38F0C1F220C7807D00FF8DD3 /* AutocompleteSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38F0C1F120C7807D00FF8DD3 /* AutocompleteSession.swift */; };
 		38F0C1F420C7808F00FF8DD3 /* AutocompleteCompletion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38F0C1F320C7808F00FF8DD3 /* AutocompleteCompletion.swift */; };
 		38F0C1FB20C8971500FF8DD3 /* InputBarAccessoryView+Availability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38F0C1FA20C8971500FF8DD3 /* InputBarAccessoryView+Availability.swift */; };
+		8883235322D965A9008861FE /* InputBarMiddleContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8883235222D965A9008861FE /* InputBarMiddleContentView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -83,6 +84,7 @@
 		38F0C1F120C7807D00FF8DD3 /* AutocompleteSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutocompleteSession.swift; sourceTree = "<group>"; };
 		38F0C1F320C7808F00FF8DD3 /* AutocompleteCompletion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutocompleteCompletion.swift; sourceTree = "<group>"; };
 		38F0C1FA20C8971500FF8DD3 /* InputBarAccessoryView+Availability.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "InputBarAccessoryView+Availability.swift"; sourceTree = "<group>"; };
+		8883235222D965A9008861FE /* InputBarMiddleContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputBarMiddleContentView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -211,6 +213,7 @@
 			isa = PBXGroup;
 			children = (
 				38C8677B1F50A6AD00811974 /* InputBarButtonItem.swift */,
+				8883235222D965A9008861FE /* InputBarMiddleContentView.swift */,
 				38570137218651C400589A30 /* InputBarSendButton.swift */,
 			);
 			path = Controls;
@@ -405,6 +408,7 @@
 				381042231F85FD1300B1E61A /* SeparatorLine.swift in Sources */,
 				38C867831F50A6AD00811974 /* InputBarButtonItem.swift in Sources */,
 				3821ADD920F5315400DE0D1D /* KeyboardNotification.swift in Sources */,
+				8883235322D965A9008861FE /* InputBarMiddleContentView.swift in Sources */,
 				38C501242148C76900246686 /* NSNotification+Extensions.swift in Sources */,
 				3876DA911F83530900C89326 /* AutocompleteManagerDelegate.swift in Sources */,
 				3821ADDA20F5315400DE0D1D /* KeyboardManager.swift in Sources */,

--- a/Sources/Controls/InputBarMiddleContentView.swift
+++ b/Sources/Controls/InputBarMiddleContentView.swift
@@ -1,0 +1,158 @@
+//
+//  InputBarMiddleContentView.swift
+//  InputBarAccessoryView
+//
+//  Copyright © 2017-2019 Nathan Tannar.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+//  Created by Marc Etcheverry on 7/12/19.
+//
+
+import UIKit
+
+public protocol InputBarMiddleContentViewDelegate: class {
+    func inputTextViewDidChange()
+    func inputTextViewDidBeginEditing()
+    func inputTextViewDidEndEditing()
+    func didSwipeTextView(_ gesture: UISwipeGestureRecognizer)
+}
+
+/// You can adopt this protocol to implement a middle content view that goes beyond a simple `InputTextView`
+/// You must have a principal `InputTextView` as this is a requirement for `InputBarAccessoryView`.
+/// `isScrollEnabled` will be called by `InputBarAccessoryView` if max height is constrained for the middle content view.
+public protocol InputBarMiddleContentView: UIView {
+    var delegate: InputBarMiddleContentViewDelegate? { get set }
+    var canSend: Bool { get }
+    var isScrollEnabled: Bool { get set }
+    var inputTextView: InputTextView { get set }
+}
+
+/// A default implementation of `InputBarMiddleContentView` with one `InputTextView`
+internal class InputBarDefaultMiddleContentView: UIView, InputBarMiddleContentView {
+    weak var delegate: InputBarMiddleContentViewDelegate?
+
+    public convenience init() {
+        self.init(frame: .zero)
+    }
+
+    public override init(frame: CGRect) {
+        super.init(frame: frame)
+        setup()
+    }
+
+    required public init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        setup()
+    }
+
+    private func setup() {
+        addSubview(inputTextView)
+        inputTextView.fillSuperview()
+
+        setupObservers()
+        setupGestureRecognizers()
+    }
+
+    /// Adds a UISwipeGestureRecognizer for each direction to the InputTextView
+    private func setupGestureRecognizers() {
+        let directions: [UISwipeGestureRecognizer.Direction] = [.left, .right]
+        for direction in directions {
+            let gesture = UISwipeGestureRecognizer(target: self,
+                                                   action: #selector(InputBarDefaultMiddleContentView.didSwipeTextView(_:)))
+            gesture.direction = direction
+            inputTextView.addGestureRecognizer(gesture)
+        }
+    }
+
+    private func setupObservers() {
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(InputBarDefaultMiddleContentView.inputTextViewDidChange),
+                                               name: UITextView.textDidChangeNotification, object: inputTextView)
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(InputBarDefaultMiddleContentView.inputTextViewDidBeginEditing),
+                                               name: UITextView.textDidBeginEditingNotification, object: inputTextView)
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(InputBarDefaultMiddleContentView.inputTextViewDidEndEditing),
+                                               name: UITextView.textDidEndEditingNotification, object: inputTextView)
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self,
+                                                  name: UITextView.textDidChangeNotification, object: inputTextView)
+        NotificationCenter.default.removeObserver(self,
+                                                  name: UITextView.textDidBeginEditingNotification, object: inputTextView)
+        NotificationCenter.default.removeObserver(self,
+                                                  name: UITextView.textDidEndEditingNotification, object: inputTextView)
+    }
+
+    @objc
+    open func inputTextViewDidChange() {
+        delegate?.inputTextViewDidChange()
+    }
+
+    @objc
+    open func inputTextViewDidBeginEditing() {
+        delegate?.inputTextViewDidBeginEditing()
+    }
+
+    @objc
+    open func inputTextViewDidEndEditing() {
+        delegate?.inputTextViewDidEndEditing()
+    }
+
+    /// Calls each items `keyboardSwipeGestureAction` method
+    /// Calls the delegates `didSwipeTextViewWith` method
+    @objc
+    open func didSwipeTextView(_ gesture: UISwipeGestureRecognizer) {
+        delegate?.didSwipeTextView(gesture)
+    }
+
+    var canSend: Bool {
+        let trimmedText = inputTextView.text.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        var isEnabled = !trimmedText.isEmpty
+        if !isEnabled {
+            // The images property is more resource intensive so only use it if needed
+            isEnabled = inputTextView.images.count > 0
+        }
+        return isEnabled
+    }
+
+    var isScrollEnabled: Bool {
+        get {
+            return inputTextView.isScrollEnabled
+        }
+        set {
+            inputTextView.isScrollEnabled = newValue
+        }
+    }
+
+    override var intrinsicContentSize: CGSize {
+        let maxTextViewSize = CGSize(width: inputTextView.bounds.width, height: .greatestFiniteMagnitude)
+        return CGSize(width: bounds.width, height: ceil(inputTextView.sizeThatFits(maxTextViewSize).height))
+    }
+
+    lazy var inputTextView: InputTextView = {
+        let inputTextView = InputTextView()
+        inputTextView.translatesAutoresizingMaskIntoConstraints = false
+        return inputTextView
+    }()
+}
+

--- a/Sources/InputBarAccessoryView.swift
+++ b/Sources/InputBarAccessoryView.swift
@@ -557,7 +557,6 @@ open class InputBarAccessoryView: UIView {
                 middleContentViewHeightAnchor?.isActive = false || shouldForceMiddleContentViewMaxHeight
                 isOverMaxMiddleContentViewHeight = false
                 middleContentView.isScrollEnabled = false
-                middleContentView.invalidateIntrinsicContentSize()
             }
         }
         

--- a/Sources/InputBarAccessoryView.swift
+++ b/Sources/InputBarAccessoryView.swift
@@ -124,13 +124,15 @@ open class InputBarAccessoryView: UIView {
      The main view component of the InputBarAccessoryView
 
      The default value is the `InputTextView`.
+     You should subclasss to override this if you are going to use a custom one,
+     this will avoid the unecessary creation of the default one.
 
      ## Important Notes ##
      1. This view should self-size with constraints or an
         intrinsicContentSize to auto-size the InputBarAccessoryView
      2. Override with `setMiddleContentView(view: UIView?, animated: Bool)`
      */
-    public private(set) lazy var middleContentView: InputBarMiddleContentView = {
+    open private(set) lazy var middleContentView: InputBarMiddleContentView = {
         let view = InputBarDefaultMiddleContentView()
         view.inputTextView.inputBarAccessoryView = self
         view.delegate = self
@@ -669,6 +671,7 @@ open class InputBarAccessoryView: UIView {
         middleContentView.removeFromSuperview()
         guard let view = view else { return }
         middleContentView = view
+        middleContentView.delegate = self
         middleContentViewWrapper.addSubview(view)
         view.fillSuperview()
         maxMiddleContentViewHeight = calculateMaxMiddleContentViewHeight()


### PR DESCRIPTION
This is a preliminary PR to improve support for complex middle content views with InputTextFields.

This also breaks aways some of the complexity of `InputBarAccessoryView.swift` by decoupling the `InputTextView` sizing support into its own wrapper class `InputBarMiddleContentView` which encapsulates that complexity.

The impetus for this change, was to support a subject field like Messages.app does:

<img width="352" alt="Screen Shot 2019-07-12 at 6 13 39 PM" src="https://user-images.githubusercontent.com/229094/61165086-cbbfac80-a4d0-11e9-8a1b-e733225dc9e8.png">

While this is achievable today by setting a custom middle view, I found that there are a lot of pitfalls, as there is no support for handling max height (as this is based on scaling a single InputTextView rather than a custom middle view)

Also, there is a contract that `InputBarAccessoryView` will always have an `InputTextView`, whether visible or not, so this essentially codifies it. If you override with a custom middle content view, you must provide an input text view within it, as well as providing a couple of callbacks and methods that `InputBarAcessoryView` will call upon (`canSend`, `isScrollEnabled`).

This is a non-breaking change for the most part. Some methods have been renamed, so if anyone overrode them they will have to change that, but for most users there should be absolutely no change. Default behaviors are not affected besides the introduction of an extra `UIView` wrapper.

@nathantannar4 I am submitting this PR early to get some feedback on its direction. I think its a huge improvement that breaks out complexity into its own views, and allows for much more powerful customization of complex input fields. Do you think this is the right path?

**TODO:**
* Add an example of overriding with a custom subject/text as Messages.app
* Implement deprecation warnings