### PR TITLE
Set separator line to 1px and update colors for iOS 13

### DIFF
--- a/Sources/InputBarAccessoryView.swift
+++ b/Sources/InputBarAccessoryView.swift
@@ -40,7 +40,11 @@ open class InputBarAccessoryView: UIView {
     open var backgroundView: UIView = {
         let view = UIView()
         view.translatesAutoresizingMaskIntoConstraints = false
-        view.backgroundColor = .white
+        if #available(iOS 13, *) {
+            view.backgroundColor = .systemBackground
+        } else {
+            view.backgroundColor = .white
+        }
         return view
     }()
     
@@ -60,7 +64,10 @@ open class InputBarAccessoryView: UIView {
      1. The blurView is initially not added to the backgroundView to improve performance when not needed. When `isTranslucent` is set to TRUE for the first time the blurView is added and anchored to the `backgroundView`s edge anchors
     */
     open lazy var blurView: UIVisualEffectView = {
-        let blurEffect = UIBlurEffect(style: .light)
+        var blurEffect = UIBlurEffect(style: .light)
+        if #available(iOS 13, *) {
+            blurEffect = UIBlurEffect(style: .systemMaterial)
+        }
         let view = UIVisualEffectView(effect: blurEffect)
         view.translatesAutoresizingMaskIntoConstraints = false
         return view

--- a/Sources/Views/SeparatorLine.swift
+++ b/Sources/Views/SeparatorLine.swift
@@ -31,7 +31,7 @@ import UIKit
  A UIView thats intrinsicContentSize is overrided so an exact height can be specified
  
  ## Important Notes ##
- 1. Default height is 1.0
+ 1. Default height is 1 pixel
  2. Default backgroundColor is UIColor.lightGray
  3. Intended to be used in an `InputStackView`
  */
@@ -40,7 +40,7 @@ open class SeparatorLine: UIView {
     // MARK: - Properties
     
     /// The height of the line
-    open var height: CGFloat = 1.0 {
+  open var height: CGFloat = 1.0 / UIScreen.main.scale {
         didSet {
             constraints.filter { $0.identifier == "height" }.forEach { $0.constant = height } // Assumes constraint was given an identifier
             invalidateIntrinsicContentSize()
@@ -65,7 +65,11 @@ open class SeparatorLine: UIView {
     
     /// Sets up the default properties
     open func setup() {
-        backgroundColor = .lightGray
+        if #available(iOS 13, *) {
+            backgroundColor = .systemGray
+        } else {
+            backgroundColor = .lightGray
+        }
         translatesAutoresizingMaskIntoConstraints = false
         setContentHuggingPriority(.defaultHigh, for: .vertical)
     }


### PR DESCRIPTION
For #83 and #88. Also I don't have issue with #80 anymore, fwiw.