### PR TITLE
Allow edits immediately before a tag without breaking them

### DIFF
--- a/Sources/Plugins/AutocompleteManager/AutocompleteManager.swift
+++ b/Sources/Plugins/AutocompleteManager/AutocompleteManager.swift
@@ -451,12 +451,7 @@ open class AutocompleteManager: NSObject, InputPlugin, UITextViewDelegate, UITab
             guard range.location != 0 else { return true }
 
             // Inserting text in the middle of an autocompleted string
-            let attributes: [NSAttributedString.Key : Any]
-            if range.location > 0 {
-                attributes = textView.attributedText.attributes(at: range.location-1, longestEffectiveRange: nil, in: NSMakeRange(range.location-1, range.length))
-            } else {
-                attributes = textView.attributedText.attributes(at: range.location, longestEffectiveRange: nil, in: NSMakeRange(range.location, range.length))
-            }
+            let attributes = textView.attributedText.attributes(at: range.location-1, longestEffectiveRange: nil, in: NSMakeRange(range.location-1, range.length))
 
             let isAutocompleted = attributes[.autocompleted] as? Bool ?? false
             if isAutocompleted {

--- a/Sources/Plugins/AutocompleteManager/AutocompleteManager.swift
+++ b/Sources/Plugins/AutocompleteManager/AutocompleteManager.swift
@@ -92,13 +92,6 @@ open class AutocompleteManager: NSObject, InputPlugin, UITextViewDelegate, UITab
     ///
     /// Default value is `TRUE`
     open var deleteCompletionByParts = true
-    
-    /// When enabled, text input immediately before a tag will not break the link
-    /// This means a space before "@Nathan Tannar" will result in " @Nathan Tanner" without breaking the link
-    /// When disabled a space before "@Nathan Tanner" will result in " @Nathan Tanner" but it loses the link
-    ///
-    /// Default value is `FALSE`
-    open var allowEditsBeforeTag = false
 
     /// The default text attributes
     open var defaultTextAttributes: [NSAttributedString.Key: Any] =
@@ -455,11 +448,11 @@ open class AutocompleteManager: NSObject, InputPlugin, UITextViewDelegate, UITab
         } else if range.length >= 0, range.location < totalRange.length {
             
             // Inserting text before a tag when the tag is at the start of the string
-            guard !(allowEditsBeforeTag && range.location == 0) else { return true }
+            guard range.location != 0 else { return true }
 
             // Inserting text in the middle of an autocompleted string
             let attributes: [NSAttributedString.Key : Any]
-            if allowEditsBeforeTag && range.location > 0 {
+            if range.location > 0 {
                 attributes = textView.attributedText.attributes(at: range.location-1, longestEffectiveRange: nil, in: NSMakeRange(range.location-1, range.length))
             } else {
                 attributes = textView.attributedText.attributes(at: range.location, longestEffectiveRange: nil, in: NSMakeRange(range.location, range.length))

--- a/Sources/Plugins/AutocompleteManager/AutocompleteManager.swift
+++ b/Sources/Plugins/AutocompleteManager/AutocompleteManager.swift
@@ -92,7 +92,7 @@ open class AutocompleteManager: NSObject, InputPlugin, UITextViewDelegate, UITab
     ///
     /// Default value is `TRUE`
     open var deleteCompletionByParts = true
-
+    
     /// The default text attributes
     open var defaultTextAttributes: [NSAttributedString.Key: Any] =
         [.font: UIFont.preferredFont(forTextStyle: .body), .foregroundColor: UIColor.black]


### PR DESCRIPTION
There are two separate cases this covers
1. make edits at the very start of a string when it starts with a tag without breaking the link
   - This means a space before "@Nathan Tannar" will result in " @Nathan Tanner" without breaking the link.

2. make edits immediately before an inline tag without it breaking the link
   - This means any input (for ex "Sup") before the tag in "Hey@Nathan Tannar" will result in "HeySup@Nathan Tanner" without breaking the link.
