### PR TITLE
Make reuseIdentifier public

### DIFF
--- a/Sources/Plugins/AttachmentManager/Views/AttachmentCell.swift
+++ b/Sources/Plugins/AttachmentManager/Views/AttachmentCell.swift
@@ -31,7 +31,7 @@ open class AttachmentCell: UICollectionViewCell {
     
     // MARK: - Properties
     
-    class var reuseIdentifier: String {
+    public class var reuseIdentifier: String {
         return "AttachmentCell"
     }
     

--- a/Sources/Plugins/AttachmentManager/Views/ImageAttachmentCell.swift
+++ b/Sources/Plugins/AttachmentManager/Views/ImageAttachmentCell.swift
@@ -31,7 +31,7 @@ open class ImageAttachmentCell: AttachmentCell {
     
     // MARK: - Properties
     
-    override class var reuseIdentifier: String {
+    override public class var reuseIdentifier: String {
         return "ImageAttachmentCell"
     }
     


### PR DESCRIPTION
Needed as custom `AttachmentCell`’s have to be dequeued to prevent crashes.

```swift
manager.attachmentView.dequeueReusableCell(withReuseIdentifier: AttachmentCell.reuseIdentifier, for: IndexPath(item: index, section: 0))
```