### PR TITLE
Fixes a bug where autocomplete would fail after using different prefixes

### DIFF
--- a/Sources/Extensions/UITextView+Extensions.swift
+++ b/Sources/Extensions/UITextView+Extensions.swift
@@ -15,12 +15,11 @@ internal extension UITextView {
     func find(prefixes: Set<String>, with delimiterSet: CharacterSet) -> Match? {
         guard prefixes.count > 0 else { return nil }
 
-        for prefix in prefixes {
-            if let match = find(prefix: prefix, with: delimiterSet) {
-                return match
-            }
+        let matches = prefixes.compactMap { find(prefix: $0, with: delimiterSet) }
+        let sorted = matches.sorted { a, b in
+            return a.range.lowerBound > b.range.lowerBound
         }
-        return nil
+        return sorted.first
     }
     
     func find(prefix: String, with delimiterSet: CharacterSet) -> Match? {


### PR DESCRIPTION
Fixes #108 

I don't think this actually fixes the root of the problem (`find(prefix:delimiterSet:)` seems to return matches with spaces even when delimiterSet is empty or when `maxSpaceCountDuringCompletion` is 0), but it's a working workaround for now.