### PR TITLE
Added check for delimiterSet

### DIFF
--- a/Sources/Extensions/UITextView+Extensions.swift
+++ b/Sources/Extensions/UITextView+Extensions.swift
@@ -43,6 +43,8 @@ internal extension UITextView {
         let wordRange = prefixStartIndex..<cursorRange.upperBound
         let word = leadingText[wordRange]
         
+        guard word.rangeOfCharacter(from: delimiterSet) == nil else { return nil }
+        
         let location = wordRange.lowerBound.utf16Offset(in: leadingText)
         let length = wordRange.upperBound.utf16Offset(in: word) - location
         let range = NSRange(location: location, length: length)


### PR DESCRIPTION
Right now there is no use having `delimiterSet` while looking for matching words in `find(prefixes: with:` method.
It's possible to have `AutocompleteSession` containing delimiter strings, for example:
Provided that `autocompleteDelimiterSets: Set<CharacterSet> = [.whitespaces, .newlines]` 
"#hello world" string will produce `AutocompleteSession` with `filter = "hello world"` which contains whitespace

Am I right if say that the expected value of `filter` is just `hello`? if so, here is a fix