### PR TITLE
[Release 4.3.3] Update RxSwift, update Swift PM support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,13 @@
+# OS X
+.DS_Store
+
 # Xcode
-#
-# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
 
 ## Build generated
 build/
+.build
+.swiftpm
 DerivedData
-.DS_Store
 
 ## Various settings
 *.pbxuser
@@ -29,16 +31,7 @@ xcuserdata
 *.ipa
 
 # CocoaPods
-#
-# We recommend against adding the Pods directory to your .gitignore. However
-# you should judge for yourself, the pros and cons are mentioned at:
-# http://guides.cocoapods.org/using/using-cocoapods.html#should-i-ignore-the-pods-directory-in-source-control
-#
-# Pods/
+Pods
 
 # Carthage
-#
-# Add this line if you want to avoid checking in source code from Carthage dependencies.
-# Carthage/Checkouts
-
-Carthage/Build
+Carthage

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "RxSwift",
+        "repositoryURL": "https://github.com/ReactiveX/RxSwift.git",
+        "state": {
+          "branch": null,
+          "revision": "002d325b0bdee94e7882e1114af5ff4fe1e96afa",
+          "version": "5.1.1"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
             targets: ["RxExtensions"])
    ],
    dependencies: [
-        .package(url: "https://github.com/ReactiveX/RxSwift.git", from: "5.0.0")
+        .package(url: "https://github.com/ReactiveX/RxSwift.git", from: "5.1.1")
    ],
    targets: [
        .target(


### PR DESCRIPTION
- Updates SPM by adding package.resolved file here
- Updates RxSwift support to latest supporting Catalyst
- Updates gitignore file

This should be merged in and ideally released as version 4.3.3.
As discussed in https://github.com/nathantannar4/InputBarAccessoryView/pull/117 - we would then drop iOS 9, iOS 10, RxSwift (temporarily) and release version 5.0.0.

Current release 4.3.2 doesn't support SPM btw, users need to use master.

@nathantannar4 Let me know if you think we could proceed by merging this + other PRs as 4.3.3 and then proceed with the drop and prepare stuff for release 5.0.0.