### PR TITLE
Update UITextView+Extensions to be public

### DIFF
--- a/Sources/Extensions/UITextView+Extensions.swift
+++ b/Sources/Extensions/UITextView+Extensions.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-internal extension UITextView {
+public extension UITextView {
 
     typealias Match = (prefix: String, word: String, range: NSRange)
     


### PR DESCRIPTION
I'm building my own AutocompleteManager, and I'd like to re-use these functions instead of re-writing them in my target