### PR TITLE
InputTextView: allow setting of canBecomeFirstResponder + add example

### DIFF
--- a/Example/Example/SubviewExampleViewController.swift
+++ b/Example/Example/SubviewExampleViewController.swift
@@ -39,5 +39,22 @@ final class SubviewExampleViewController: CommonTableViewController {
                 self?.tableView.scrollIndicatorInsets.bottom = barHeight
         }
     }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+
+        /// This replicates instagram's behavior when commenting in a post. As of 2020-09, it appears like they have one of the best product experiences of this handling the keyboard when dismissing the UIViewController
+        self.inputBar.inputTextView.resignFirstResponder()
+        /// This is set because otherwise, if only partially dragging the left edge of the screen, and then cancelling the dismissal, on viewDidAppear UIKit appears to set the first responder back to the inputTextView (https://stackoverflow.com/a/41847448)
+        self.inputBar.inputTextView.canBecomeFirstResponder = false
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        /// The opposite of `viewWillDisappear(_:)`
+        self.inputBar.inputTextView.canBecomeFirstResponder = true
+        self.inputBar.inputTextView.becomeFirstResponder()
+    }
     
 }

--- a/Sources/Views/InputTextView.swift
+++ b/Sources/Views/InputTextView.swift
@@ -64,6 +64,12 @@ open class InputTextView: UITextView {
     
     open var isImagePasteEnabled: Bool = true
 
+    private var canBecomeFirstResponderStorage: Bool = true
+    open override var canBecomeFirstResponder: Bool {
+        get { canBecomeFirstResponderStorage }
+        set(newValue) { canBecomeFirstResponderStorage = newValue }
+    }
+
     /// A UILabel that holds the InputTextView's placeholder text
     public let placeholderLabel: UILabel = {
         let label = UILabel()


### PR DESCRIPTION
I was working on implementing this, and using the example app as a playground was the easiest way to prototype
