### PR TITLE
add exclude for Info.plist to remove Package Loading warning

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,8 @@ let package = Package(
    targets: [
        .target(
            name: "InputBarAccessoryView",
-           path: "Sources"
+           path: "Sources",
+        exclude: ["Supporting/Info.plist"]
        )
    ],
    swiftLanguageVersions: [.v5]


### PR DESCRIPTION
The warning is generated on Xcode 12 after updating to latest suggested project settings. 