### PR TITLE
AttachmentCell - open reuseIdentifier

### DIFF
--- a/Sources/Plugins/AttachmentManager/Views/AttachmentCell.swift
+++ b/Sources/Plugins/AttachmentManager/Views/AttachmentCell.swift
@@ -31,7 +31,7 @@ open class AttachmentCell: UICollectionViewCell {
     
     // MARK: - Properties
     
-    public class var reuseIdentifier: String {
+    open class var reuseIdentifier: String {
         return "AttachmentCell"
     }
     

--- a/Sources/Plugins/AttachmentManager/Views/ImageAttachmentCell.swift
+++ b/Sources/Plugins/AttachmentManager/Views/ImageAttachmentCell.swift
@@ -31,7 +31,7 @@ open class ImageAttachmentCell: AttachmentCell {
     
     // MARK: - Properties
     
-    override public class var reuseIdentifier: String {
+    override open class var reuseIdentifier: String {
         return "ImageAttachmentCell"
     }
     


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
**Plugins/AttachmentManager**

Uses **open** instead of **public** for the **reuseIdentifier** properties in **AttachmentCell** and **ImageAttachmentCell**.

As a result these classes are suitable for inheritance.

Does this close any currently open issues?
------------------------------------------
#145 


Any relevant logs, error output, etc?
-------------------------------------


Any other comments?
-------------------


Where has this been tested?
---------------------------
**Devices/Simulators:** iPhone X / Simulator iPhone 11 Pro

**iOS Version:** 13.5 / 14.0

**Swift Version:** 5

**InputBarAccessoryView Version:** 5.2.1


