### PR TITLE
Add dark mode support for loading indicator on send button

### DIFF
--- a/Sources/Controls/InputBarSendButton.swift
+++ b/Sources/Controls/InputBarSendButton.swift
@@ -43,7 +43,14 @@ open class InputBarSendButton: InputBarButtonItem {
     }
 
     private let activityView: UIActivityIndicatorView = {
-        let view = UIActivityIndicatorView(style: .gray)
+        let view: UIActivityIndicatorView
+        
+        if #available(iOS 13.0, *) {
+            view = UIActivityIndicatorView(style: .medium)
+        } else {
+            view = UIActivityIndicatorView(style: .gray)
+        }
+        
         view.isUserInteractionEnabled = false
         view.isHidden = true
         return view


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------

- When using dark mode, the loading indicator that can be displayed on the send button was not visible because it was not using the updated styles available in iOS 13+.

Any other comments?
-------------------

Before & After

<img src="https://user-images.githubusercontent.com/25673485/97743994-dc78a500-1abc-11eb-9e44-08ce8b522d8c.png" width="300"> <img src="https://user-images.githubusercontent.com/25673485/97743867-afc48d80-1abc-11eb-8d6c-09bb05aa204b.png" width="300">


Where has this been tested?
---------------------------
**Devices/Simulators:** iPhone 8, iPhone 12

**iOS Version:** iOS 12 and 13

**Swift Version:** Swift 5

**InputBarAccessoryView Version:** Latest


