### PR TITLE
Fix for iOS 14 paste notification

### DIFF
--- a/Sources/Views/InputTextView.swift
+++ b/Sources/Views/InputTextView.swift
@@ -234,8 +234,8 @@ open class InputTextView: UITextView {
     // MARK: - Image Paste Support
     
     open override func canPerformAction(_ action: Selector, withSender sender: Any?) -> Bool {
-        
-        if action == NSSelectorFromString("paste:") && UIPasteboard.general.image != nil {
+
+        if action == NSSelectorFromString("paste:") && UIPasteboard.general.hasImages {
             return isImagePasteEnabled
         }
         return super.canPerformAction(action, withSender: sender)


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
Fixes #175 

Does this close any currently open issues?
------------------------------------------
#175 


Any relevant logs, error output, etc?
-------------------------------------
<!--
If the logs is quite long, please paste to https://ghostbin.com/ and insert the link here.
-->

Any other comments?
-------------------
Can no longer directly access pasteboard without the system notifying the user 

Where has this been tested?
---------------------------
**Devices/Simulators:** XS Max

**iOS Version:** iOS 14.1

**Swift Version:** 5.3

**InputBarAccessoryView Version:** 5.2.0


