### PR TITLE
Apply additionalBottomSpace to interactive dismissal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 #  Changelog
 - Master:
-   - Nothing yet
+   - Applied `additionalBottomSpace` to interactive dismissal
 - 5.3.0
    - Allow setting `canBecomeFirstResponder`
    - Fix interactive keyboard dismissal lag

--- a/Sources/KeyboardManager/KeyboardManager.swift
+++ b/Sources/KeyboardManager/KeyboardManager.swift
@@ -42,8 +42,16 @@ open class KeyboardManager: NSObject, UIGestureRecognizerDelegate {
     /// A flag that indicates if a portion of the keyboard is visible on the screen
     private(set) public var isKeyboardHidden: Bool = true
     
+    /// A flag that indicates if the additional bottom space should be applied to
+    /// the interactive dismissal of the keyboard
+    public var shouldApplyAdditionBottomSpaceToInteractiveDismissal: Bool = false
+
     // MARK: - Properties [Private]
     
+    /// The additional bottom space specified for laying out the input accessory view
+    /// when binding to it
+    private var additionalBottomSpace: (() -> CGFloat)?
+
     /// The `NSLayoutConstraintSet` that holds the `inputAccessoryView` to the bottom if its superview
     private var constraints: NSLayoutConstraintSet?
     
@@ -143,6 +151,7 @@ open class KeyboardManager: NSObject, UIGestureRecognizerDelegate {
             fatalError("`inputAccessoryView` must have a superview")
         }
         self.inputAccessoryView = inputAccessoryView
+        self.additionalBottomSpace = additionalBottomSpace
         inputAccessoryView.translatesAutoresizingMaskIntoConstraints = false
         constraints = NSLayoutConstraintSet(
             bottom: inputAccessoryView.bottomAnchor.constraint(equalTo: superview.bottomAnchor),
@@ -287,7 +296,12 @@ open class KeyboardManager: NSObject, UIGestureRecognizerDelegate {
         frame.size.height = window.bounds.height - frame.origin.y
         keyboardNotification.endFrame = frame
 
-        let yCoordinateDirectlyAboveKeyboard = -frame.height
+        var yCoordinateDirectlyAboveKeyboard = -frame.height
+
+        if shouldApplyAdditionBottomSpaceToInteractiveDismissal {
+            yCoordinateDirectlyAboveKeyboard -= additionalBottomSpace?() ?? 0
+        }
+
         /// If a tab bar is shown, letting this number becoming > 0 makes it so the accessoryview disappears below the tab bar. setting the max value to 0 prevents that
         let aboveKeyboardAndAboveTabBar = min(0, yCoordinateDirectlyAboveKeyboard)
         self.constraints?.bottom?.constant = aboveKeyboardAndAboveTabBar

--- a/Sources/KeyboardManager/KeyboardManager.swift
+++ b/Sources/KeyboardManager/KeyboardManager.swift
@@ -298,8 +298,9 @@ open class KeyboardManager: NSObject, UIGestureRecognizerDelegate {
 
         var yCoordinateDirectlyAboveKeyboard = -frame.height
 
-        if shouldApplyAdditionBottomSpaceToInteractiveDismissal {
-            yCoordinateDirectlyAboveKeyboard -= additionalBottomSpace?() ?? 0
+        if shouldApplyAdditionBottomSpaceToInteractiveDismissal,
+           let additionalBottomSpace = additionalBottomSpace {
+            yCoordinateDirectlyAboveKeyboard -= additionalBottomSpace()
         }
 
         /// If a tab bar is shown, letting this number becoming > 0 makes it so the accessoryview disappears below the tab bar. setting the max value to 0 prevents that


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
This PR addresses the issue linked below. 
- Allowed additional bottom space to be applied to the interactive keyboard dismissal
- Added a flag to determine if the additional bottom space should also be applied

Does this close any currently open issues?
------------------------------------------
Closes #198 


Where has this been tested?
---------------------------
**Devices/Simulators:** Simulators

**iOS Version:** 14.4

**Swift Version:** 5

**InputBarAccessoryView Version:** 5.3.0


