### PR TITLE
KeyboardManager reset cachedNotification onHide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 #  Changelog
 - Master:
-   - Nothing yet
+   - Reset cachedNotification when keyboard is programmatically dismissed
 - 5.3.1
    - Applied `additionalBottomSpace` to interactive dismissal
 - 5.3.0

--- a/Sources/KeyboardManager/KeyboardManager.swift
+++ b/Sources/KeyboardManager/KeyboardManager.swift
@@ -224,6 +224,7 @@ open class KeyboardManager: NSObject, UIGestureRecognizerDelegate {
         isKeyboardHidden = true
         guard let keyboardNotification = KeyboardNotification(from: notification) else { return }
         callbacks[.didHide]?(keyboardNotification)
+        cachedNotification = nil
     }
     
     /// An observer method called third in the lifecycle of a keyboard becoming visible/hidden
@@ -263,6 +264,7 @@ open class KeyboardManager: NSObject, UIGestureRecognizerDelegate {
     open func keyboardWillHide(notification: NSNotification) {
         guard let keyboardNotification = KeyboardNotification(from: notification) else { return }
         callbacks[.willHide]?(keyboardNotification)
+        cachedNotification = nil
     }
     
     // MARK: - Helper Methods


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This fix resets the cached notification that contains the keyboard start and end frames when the keyboard is hidden. The cached notification keeps track of the last position of the keyboard so that the pan gesture can correctly calculate the position of the input bar (see KeyboardManager.handlePanGestureRecognizer()).

There is an issue within the handlePanGestureRecognizer() algorithm when the keyboard gets dismissed programmatically. The cached notification contains the incorrect frames when it solely relies on being set from the willChangeFrame and didChangeFrame notifications. We expect the startFrame and endFrame of the notification to be the same, but they are not. 
This code within KeyboardManager.handlePanGestureRecognizer() is the problematic code fails:

```swift
// if there's no difference in frames for the `cachedNotification`, no adjustment is necessary. 
// This is true when the keyboard is completely dismissed, or our pan doesn't intersect below the keyboard
guard cachedNotification?.startFrame != cachedNotification?.endFrame else { return }
```

By resetting the cachedNotification onHide, the issue is resolved because now, it treats the hidden keyboard as no adjustments necessary.

Does this close any currently open issues?
------------------------------------------
Yes #207 

Where has this been tested?
---------------------------
**Devices/Simulators:** Both

**iOS Version:** 14.5

**Swift Version:** 5.4

**InputBarAccessoryView Version:** 5.3.1


