### PR TITLE
AutoComplete attributed text dark mode support add

### DIFF
--- a/Sources/Plugins/AutocompleteManager/AutocompleteManager.swift
+++ b/Sources/Plugins/AutocompleteManager/AutocompleteManager.swift
@@ -349,6 +349,11 @@ open class AutocompleteManager: NSObject, InputPlugin, UITextViewDelegate, UITab
         // Replace the attributedText with a modified version including the autocompete
         let newAttributedText = textView.attributedText.replacingCharacters(in: highlightedRange, with: newAttributedString)
         
+        // make background clear for dark mode support
+        newAttributedText.addAttribute(NSAttributedString.Key.backgroundColor,
+                                       value: UIColor.clear,
+                                       range: NSMakeRange(0, newAttributedText.length))
+        
         // Set to a blank attributed string to prevent keyboard autocorrect from cloberring the insert
         textView.attributedText = NSAttributedString()
 


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Provides dark mode support for auto-completion in `AutoCompleteManger`.

Does this close any currently open issues?
------------------------------------------
Closes #205 

Any relevant logs, error output, etc?
-------------------------------------
No

Any other comments?
-------------------
No

Where has this been tested?
---------------------------
**Devices/Simulators:** Device

**iOS Version:** 14.4.2

**Swift Version:** Swift 5

**InputBarAccessoryView Version:** 5.1.0


