### PR TITLE
Mark KeyboardManager unavailable in extension

### DIFF
--- a/Sources/KeyboardManager/KeyboardManager.swift
+++ b/Sources/KeyboardManager/KeyboardManager.swift
@@ -28,6 +28,7 @@
 import UIKit
 
 /// An object that observes keyboard notifications such that event callbacks can be set for each notification
+@available(iOSApplicationExtension, unavailable)
 open class KeyboardManager: NSObject, UIGestureRecognizerDelegate {
     
     /// A callback that passes a `KeyboardNotification` as an input


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
Fix compilation on Xcode 13.

Does this close any currently open issues?
------------------------------------------
https://github.com/nathantannar4/InputBarAccessoryView/issues/213


Any relevant logs, error output, etc?
-------------------------------------
No.

Where has this been tested?
---------------------------
**Devices/Simulators:** iPhone 12 Pro

**iOS Version:** iOS 15 Beta 4

**Swift Version:** Swift 5.5

**InputBarAccessoryView Version:** master branch


