### PR TITLE
Custom Attachment Size

### DIFF
--- a/Sources/Plugins/AttachmentManager/AttachmentManager.swift
+++ b/Sources/Plugins/AttachmentManager/AttachmentManager.swift
@@ -202,6 +202,10 @@ extension AttachmentManager: UICollectionViewDataSource, UICollectionViewDelegat
     
     final public func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
         
+        if let customSize = self.dataSource?.attachmentManager(self, sizeFor: self.attachments[indexPath.row], at: indexPath.row){
+            return customSize
+        }
+        
         var height = attachmentView.intrinsicContentHeight
         if let layout = collectionView.collectionViewLayout as? UICollectionViewFlowLayout {
             height -= (layout.sectionInset.bottom + layout.sectionInset.top + collectionView.contentInset.top + collectionView.contentInset.bottom)

--- a/Sources/Plugins/AttachmentManager/Protocols/AttachmentManagerDataSource.swift
+++ b/Sources/Plugins/AttachmentManager/Protocols/AttachmentManagerDataSource.swift
@@ -26,6 +26,7 @@
 //
 
 import Foundation
+import UIKit
 
 /// AttachmentManagerDataSource is a protocol to passes data to the AttachmentManager
 public protocol AttachmentManagerDataSource: AnyObject {
@@ -38,4 +39,13 @@ public protocol AttachmentManagerDataSource: AnyObject {
     ///   - index: The index in the AttachmentView
     /// - Returns: An AttachmentCell
     func attachmentManager(_ manager: AttachmentManager, cellFor attachment: AttachmentManager.Attachment, at index: Int) -> AttachmentCell
+    
+    /// The CGSize of the AttachmentCell for the attachment that is to be inserted into the AttachmentView
+    ///
+    /// - Parameters:
+    ///   - manager: The AttachmentManager
+    ///   - attachment: The object
+    ///   - index: The index in the AttachmentView
+    /// - Returns: The size of the given attachment
+    func attachmentManager(_ manager: AttachmentManager, sizeFor attachment: AttachmentManager.Attachment, at index: Int) -> CGSize?
 }

--- a/Sources/Plugins/AttachmentManager/Protocols/AttachmentManagerDataSource.swift
+++ b/Sources/Plugins/AttachmentManager/Protocols/AttachmentManagerDataSource.swift
@@ -49,3 +49,11 @@ public protocol AttachmentManagerDataSource: AnyObject {
     /// - Returns: The size of the given attachment
     func attachmentManager(_ manager: AttachmentManager, sizeFor attachment: AttachmentManager.Attachment, at index: Int) -> CGSize?
 }
+
+public extension AttachmentManagerDataSource{
+    
+    // Default implementation, if data source method is not given, use autocalculated default.
+    func attachmentManager(_ manager: AttachmentManager, sizeFor attachment: AttachmentManager.Attachment, at index: Int) -> CGSize? {
+        return nil
+    }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
This implements a simple (optional) AttachmentManagerDataSource method to allow for custom attachment sizes.
For my own app, I found this functionality very needed and it has been tested continuously throughout my app's development with no issues. 

Does this close any currently open issues?
------------------------------------------

Not to my knowledge, based on what I have seen/

Any relevant logs, error output, etc?
-------------------------------------
<!--
If the logs is quite long, please paste to https://ghostbin.com/ and insert the link here.
-->

Any other comments?
-------------------
This feature could be seen as niche but when it is needed, it is very helpful.

Where has this been tested?
---------------------------
**Devices/Simulators:** iPhoneXR, iPhone11, iPhone12, (+Max variants), iPad Air 4

**iOS Version:** iOS 14, iOS 15

**Swift Version:** Swift 4, Swift 5

**InputBarAccessoryView Version:** 5.4.0


