### PR TITLE
Added extra animations option for left/right stack view constraints

### DIFF
--- a/Sources/InputBarAccessoryView.swift
+++ b/Sources/InputBarAccessoryView.swift
@@ -785,11 +785,15 @@ open class InputBarAccessoryView: UIView {
     /// - Parameters:
     ///   - newValue: New widthAnchor constant
     ///   - animated: If the layout should be animated
-    open func setLeftStackViewWidthConstant(to newValue: CGFloat, animated: Bool) {
+    ///   - extraAnimations: Any extra operations that should also be animated
+    open func setLeftStackViewWidthConstant(to newValue: CGFloat, animated: Bool, extraAnimations : (() -> Void)? = nil) {
         performLayout(animated) { 
             self.leftStackViewWidthConstant = newValue
             self.layoutStackViews([.left])
             self.layoutContainerViewIfNeeded()
+            if let animations = extraAnimations{
+                animations()
+            }
         }
     }
     
@@ -798,11 +802,15 @@ open class InputBarAccessoryView: UIView {
     /// - Parameters:
     ///   - newValue: New widthAnchor constant
     ///   - animated: If the layout should be animated
-    open func setRightStackViewWidthConstant(to newValue: CGFloat, animated: Bool) {
+    ///   - extraAnimations: Any extra operations that should also be animated
+    open func setRightStackViewWidthConstant(to newValue: CGFloat, animated: Bool, extraAnimations : (() -> Void)? = nil) {
         performLayout(animated) { 
             self.rightStackViewWidthConstant = newValue
             self.layoutStackViews([.right])
             self.layoutContainerViewIfNeeded()
+            if let animations = extraAnimations{
+                animations()
+            }
         }
     }
     

--- a/Sources/InputBarAccessoryView.swift
+++ b/Sources/InputBarAccessoryView.swift
@@ -786,14 +786,12 @@ open class InputBarAccessoryView: UIView {
     ///   - newValue: New widthAnchor constant
     ///   - animated: If the layout should be animated
     ///   - extraAnimations: Any extra operations that should also be animated
-    open func setLeftStackViewWidthConstant(to newValue: CGFloat, animated: Bool, extraAnimations : (() -> Void)? = nil) {
+    open func setLeftStackViewWidthConstant(to newValue: CGFloat, animated: Bool, animations : (() -> Void)? = nil) {
         performLayout(animated) { 
             self.leftStackViewWidthConstant = newValue
             self.layoutStackViews([.left])
             self.layoutContainerViewIfNeeded()
-            if let animations = extraAnimations{
-                animations()
-            }
+            animations?()
         }
     }
     
@@ -803,14 +801,12 @@ open class InputBarAccessoryView: UIView {
     ///   - newValue: New widthAnchor constant
     ///   - animated: If the layout should be animated
     ///   - extraAnimations: Any extra operations that should also be animated
-    open func setRightStackViewWidthConstant(to newValue: CGFloat, animated: Bool, extraAnimations : (() -> Void)? = nil) {
+    open func setRightStackViewWidthConstant(to newValue: CGFloat, animated: Bool, animations : (() -> Void)? = nil) {
         performLayout(animated) { 
             self.rightStackViewWidthConstant = newValue
             self.layoutStackViews([.right])
             self.layoutContainerViewIfNeeded()
-            if let animations = extraAnimations{
-                animations()
-            }
+            animations?()
         }
     }
     


### PR DESCRIPTION


<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
When adjusting the left and right stack view width constraints, while I liked having them animated, I felt like there needed to be a way to run other animations concurrently. 

One example would be changing the alpha component of the stack view items as they are compressed so they don't appear small in the end. 

Because of this, I added a simple optional closure which, if specified, is called while animating to also animate the given properties. 

Does this close any currently open issues?
------------------------------------------
Not that I am aware of.


Any relevant logs, error output, etc?
-------------------------------------
<!--
If the logs is quite long, please paste to https://ghostbin.com/ and insert the link here.
-->

Any other comments?
-------------------
The name of the closure variable and the comments can and maybe should be renamed if someone has a better idea.

Where has this been tested?
---------------------------
**Devices/Simulators:** …
iPhone XR Device, iPhone 11, 11 Pro, 12, 12 Pro Simulators
**iOS Version:** …
15.0
**Swift Version:** …
5.0
**InputBarAccessoryView Version:** …
5.4

