### PR TITLE
inputAccessoryView position with floating keyboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 #  Changelog
 - Master:
+   - KeyboardManager will not update position of inputAccessoryView from interactive dismiss panGesture when the keyboard is floating
+- 5.5.0
+   - Update SPM tools to Swift 5.5
+   - Added new optional delegate method for custom attachments size
+   - Added new animations for left/right stack view constraints
 - 5.4.0
    - Make sure framework is ready for XCode 13
    - Fix availability in AppExtensions

--- a/Sources/KeyboardManager/KeyboardManager.swift
+++ b/Sources/KeyboardManager/KeyboardManager.swift
@@ -289,9 +289,16 @@ open class KeyboardManager: NSObject, UIGestureRecognizerDelegate {
             let window = UIApplication.shared.windows.first
             else { return }
 
-        // if there's no difference in frames for the `cachedNotification`, no adjustment is necessary. This is true when the keyboard is completely dismissed, or our pan doesn't intersect below the keyboard
-        guard cachedNotification?.startFrame != cachedNotification?.endFrame else { return }
-        
+        guard
+            // if there's no difference in frames for the `cachedNotification`, no adjustment is necessary. This is true when the keyboard is completely dismissed, or our pan doesn't intersect below the keyboard
+            keyboardNotification.startFrame != keyboardNotification.endFrame,
+            // when the width of the keyboard from endFrame is smaller than the width of scrollView manager is tracking
+            // with panGesture, we can assume the keyboard is floatig ahd updating inputAccessoryView is not necessary
+                keyboardNotification.endFrame.width >= view.frame.width
+        else {
+            return
+        }
+
         let location = recognizer.location(in: view)
         let absoluteLocation = view.convert(location, to: window)
         var frame = keyboardNotification.endFrame


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
- KeyboardManager would update position of inputAccessoryView even when the keyboard was undocked and floating

![Simulator Screen Shot - iPad Pro (11-inch) (3rd generation) - 2022-05-03 at 14 10 44](https://user-images.githubusercontent.com/5503097/166450389-e34c428f-58d4-43ac-ba29-1c2c9575d60e.png)

Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, etc?
-------------------------------------
<!--
If the logs is quite long, please paste to https://ghostbin.com/ and insert the link here.
-->

Any other comments?
-------------------
…

Where has this been tested?
---------------------------
**Devices/Simulators:** …

**iOS Version:** …

**Swift Version:** …

**InputBarAccessoryView Version:** …


