### PR TITLE
Fix Xcode case in the project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
    - Added new optional delegate method for custom attachments size
    - Added new animations for left/right stack view constraints
 - 5.4.0
-   - Make sure framework is ready for XCode 13
+   - Make sure framework is ready for Xcode 13
    - Fix availability in AppExtensions
    - Fix Package.swift to support iOS 12+ only
    - Reset cachedNotification when keyboard is programmatically dismissed
@@ -32,7 +32,7 @@
    - Fix SPM warnings about Info.plist file
 - 5.2.0
     - Drop support for iOS 11 and bump minimum version to iOS 12+
-    - Support Swift 5.3 and higher for XCode 12
+    - Support Swift 5.3 and higher for Xcode 12
 - 5.1.0
     - Added support for smooth height transitions when the text view expands, set `shouldAnimateTextDidChangeLayout` to `true`
     - Fixed accessibility of `HorizontalEdgePadding` initializers and a typo in its filename
@@ -120,7 +120,7 @@
 - 1.3.0
     - iPhone X Correctedes
 - 1.2.0
-    - Better XCode docs
+    - Better Xcode docs
     - `InputItem` is now a protocol that you can give to the `InputBarAccessoryView`
     - `InputPlugin` is now a protocol that you can conform to make a plugin
     - `AutocompleteManager` and `AttactchmentManager` are no longer members of  `InputBarAccessoryView` by default. You will need to create them and assign them to the `InputPlugin` property of the `InputBarAccessoryView`

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ dependencies: [
     .package(url: "https://github.com/nathantannar4/InputBarAccessoryView.git", .upToNextMajor(from: "6.0.0"))
 ]
 ```
-You can also add it via XCode SPM editor with URL:
+You can also add it via Xcode SPM editor with URL:
 ```
 https://github.com/nathantannar4/InputBarAccessoryView.git
 ```
@@ -86,7 +86,7 @@ iMessage style [TypingIndicator](https://github.com/nathantannar4/TypingIndicato
    - Added new animations for left/right stack view constraints
 
 5.4.0
-   - Make sure framework is ready for XCode 13
+   - Make sure framework is ready for Xcode 13
    - Fix availability in AppExtensions
    - Fix Package.swift to support iOS 12+ only
 
@@ -106,7 +106,7 @@ iMessage style [TypingIndicator](https://github.com/nathantannar4/TypingIndicato
 
 5.2.0
    - Drop support for iOS 11 and bump minimum version to iOS 12+
-   - Support Swift 5.3 and higher for XCode 12
+   - Support Swift 5.3 and higher for Xcode 12
     
 See [CHANGELOG](./CHANGELOG.md) for more details and older releases.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -201,7 +201,7 @@ Once you have your Swift package set up, adding InputBarAccessoryView as a depen
 ]
 </code></pre>
 
-<p>You can also add it via XCode SPM editor with URL:</p>
+<p>You can also add it via Xcode SPM editor with URL:</p>
 <pre class="highlight plaintext"><code>https://github.com/nathantannar4/InputBarAccessoryView.git
 </code></pre>
 
@@ -276,7 +276,7 @@ Swift 5.5</p>
 <p>5.4.0</p>
 
 <ul>
-<li>Make sure framework is ready for XCode 13</li>
+<li>Make sure framework is ready for Xcode 13</li>
 <li>Fix availability in AppExtensions</li>
 <li>Fix Package.swift to support iOS 12+ only</li>
 </ul>
@@ -308,7 +308,7 @@ Swift 5.5</p>
 
 <ul>
 <li>Drop support for iOS 11 and bump minimum version to iOS 12+</li>
-<li>Support Swift 5.3 and higher for XCode 12</li>
+<li>Support Swift 5.3 and higher for Xcode 12</li>
 </ul>
 
 <p>See <a href="./CHANGELOG.md">CHANGELOG</a> for more details and older releases.</p>


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Nothing changed in the code, it’s just a typo fix (it’s `Xcode`, not `XCode`).

Does this close any currently open issues?
------------------------------------------
I don’t think so.


Any relevant logs, error output, etc?
-------------------------------------
None.

Any other comments?
-------------------
None.

Where has this been tested?
---------------------------
**Devices/Simulators:** N/A

**iOS Version:** N/A

**Swift Version:** N/A

**InputBarAccessoryView Version:** N/A


