### PR TITLE
Add AttachmentPicked file type in AttachmentManager

### DIFF
--- a/Sources/Plugins/AttachmentManager/AttachmentManager.swift
+++ b/Sources/Plugins/AttachmentManager/AttachmentManager.swift
@@ -33,6 +33,7 @@ open class AttachmentManager: NSObject, InputPlugin {
         case image(UIImage)
         case url(URL)
         case data(Data)
+        case attachment(AttachmentPicked)
         
         @available(*, deprecated, message: ".other(AnyObject) has been depricated as of 2.0.0")
         case other(AnyObject)

--- a/Sources/Plugins/AttachmentManager/Models/AttachmentPicked.swift
+++ b/Sources/Plugins/AttachmentManager/Models/AttachmentPicked.swift
@@ -1,0 +1,20 @@
+//
+//  File.swift
+//  
+//
+//  Created by Bruno Antoninho on 07/06/2022.
+//
+
+import Foundation
+
+public class AttachmentPicked {
+    
+    var fileType: String!
+    var fileName: String!
+    var fileSize: Int!
+    var mimeType: String!
+    var blob: String!
+    
+    //For internal use
+    var uncompressedFile: Data!
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
…

Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, etc?
-------------------------------------
<!--
If the logs is quite long, please paste to https://ghostbin.com/ and insert the link here.
-->

Any other comments?
-------------------
…

Where has this been tested?
---------------------------
**Devices/Simulators:** …

**iOS Version:** …

**Swift Version:** …

**InputBarAccessoryView Version:** …


