### PR TITLE
feat: key commands for external keyboards

### DIFF
--- a/Sources/InputBarAccessoryView.swift
+++ b/Sources/InputBarAccessoryView.swift
@@ -344,7 +344,7 @@ open class InputBarAccessoryView: UIView {
     // MARK: - Auto-Layout Constraint Sets
     
     private var middleContentViewLayoutSet: NSLayoutConstraintSet?
-    private var textViewHeightAnchor: NSLayoutConstraint?
+    open var textViewHeightAnchor: NSLayoutConstraint?
     private var topStackViewLayoutSet: NSLayoutConstraintSet?
     private var leftStackViewLayoutSet: NSLayoutConstraintSet?
     private var rightStackViewLayoutSet: NSLayoutConstraintSet?

--- a/Sources/KeyboardManager/KeyboardManager.swift
+++ b/Sources/KeyboardManager/KeyboardManager.swift
@@ -187,7 +187,6 @@ open class KeyboardManager: NSObject, UIGestureRecognizerDelegate {
             }
         }
         callbacks[.willHide] = { [weak self] (notification) in
-            guard notification.isForCurrentApp else { return }
             self?.animateAlongside(notification) { [weak self] in
                 self?.constraints?.bottom?.constant = self?.additionalInputViewBottomConstraintConstant() ?? 0
                 self?.inputAccessoryView?.superview?.layoutIfNeeded()


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Support for external keyboard to send messages by pressing command + enter.
On the Mac catalyst, it also supports keyboard shortcuts.

Does this close any currently open issues?
------------------------------------------
No



Where has this been tested?
---------------------------
**Devices/Simulators:** …
iPad mini 6
**iOS Version:** …
iOS 16.2
**Swift Version:** …
5.7

How to use:
```
messageInputBar.inputTextView.observeKeyInput("\r", modifiers: .command, discoverabilityTitle: nil) {
    // send message with command + enter
}
```


