### PR TITLE
Fix layout issues on iPad pagesheets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 #  Changelog
 - Master:
-   - Nothing yet
+   - Fixed the gap between keyboard and input bar when used on pagesheet/formsheet on iPad
 - 6.2.0
    - Remove `canBecomeFirstResponder` on `InputTextView` to fix `UITextViewDelegate` methods not being called
 - 6.1.1

--- a/Sources/KeyboardManager/KeyboardManager.swift
+++ b/Sources/KeyboardManager/KeyboardManager.swift
@@ -181,19 +181,19 @@ open func bind(inputAccessoryView: UIView, withAdditionalBottomSpace additionalB
         else { return }
 
         let keyboardHeight = notification.endFrame.height
-        self?.animateAlongside(notification) {
-            self?.constraints?.bottom?.constant = min(0, -keyboardHeight + (self?.bottomGap ?? 0)) - (additionalBottomSpace?() ?? 0)
-            self?.inputAccessoryView?.superview?.layoutIfNeeded()
+        let animateAlongside = {
+            self?.animateAlongside(notification) {
+                self?.constraints?.bottom?.constant = min(0, -keyboardHeight + (self?.bottomGap ?? 0)) - (additionalBottomSpace?() ?? 0)
+                self?.inputAccessoryView?.superview?.layoutIfNeeded()
+            }
         }
+        animateAlongside()
         
-        // Doing it a second time delayed is required for accurate placement
+        // Doing it a second time delayed is required for accurate placement when using pagesheet on portrait iPad
         DispatchQueue.main.async {
             let bottomGap = self?.bottomGap ?? 0
             if bottomGap != 0 {
-                self?.animateAlongside(notification) {
-                    self?.constraints?.bottom?.constant = min(0, -keyboardHeight + bottomGap) - (additionalBottomSpace?() ?? 0)
-                    self?.inputAccessoryView?.superview?.layoutIfNeeded()
-                }
+                animateAlongside()
             }
         }
     }
@@ -205,37 +205,37 @@ open func bind(inputAccessoryView: UIView, withAdditionalBottomSpace additionalB
         else {
             return
         }
-        self?.animateAlongside(notification) {
-            self?.constraints?.bottom?.constant = min(0, -keyboardHeight + (self?.bottomGap ?? 0)) - (additionalBottomSpace?() ?? 0)
-            self?.inputAccessoryView?.superview?.layoutIfNeeded()
+        let animateAlongside = {
+            self?.animateAlongside(notification) {
+                self?.constraints?.bottom?.constant = min(0, -keyboardHeight + (self?.bottomGap ?? 0)) - (additionalBottomSpace?() ?? 0)
+                self?.inputAccessoryView?.superview?.layoutIfNeeded()
+            }
         }
+        animateAlongside()
         
-        // Doing it a second time delayed is required for accurate placement
+        // Doing it a second time delayed is required for accurate placement when using pagesheet on portrait iPad
         DispatchQueue.main.async {
             let bottomGap = self?.bottomGap ?? 0
             if bottomGap != 0 && !(self?.justDidWillHide ?? false) {
-                self?.animateAlongside(notification) {
-                    self?.constraints?.bottom?.constant = min(0, -keyboardHeight + bottomGap) - (additionalBottomSpace?() ?? 0)
-                    self?.inputAccessoryView?.superview?.layoutIfNeeded()
-                }
+                animateAlongside()
             }
         }
     }
     callbacks[.willHide] = { [weak self] (notification) in
         guard notification.isForCurrentApp else { return }
         self?.justDidWillHide = true
-        self?.animateAlongside(notification) { [weak self] in
-            self?.constraints?.bottom?.constant = self?.additionalInputViewBottomConstraintConstant() ?? 0
-            self?.inputAccessoryView?.superview?.layoutIfNeeded()
-        }
-        
-        // Doing it a second time delayed is required for accurate placement
-        DispatchQueue.main.async {
-            self?.justDidWillHide = false
+        let animateAlongside = {
             self?.animateAlongside(notification) { [weak self] in
                 self?.constraints?.bottom?.constant = self?.additionalInputViewBottomConstraintConstant() ?? 0
                 self?.inputAccessoryView?.superview?.layoutIfNeeded()
             }
+        }
+        animateAlongside()
+        
+        // Doing it a second time delayed is required for accurate placement when using pagesheet on portrait iPad
+        DispatchQueue.main.async {
+            self?.justDidWillHide = false
+            animateAlongside()
         }
     }
     return self

--- a/Sources/KeyboardManager/KeyboardManager.swift
+++ b/Sources/KeyboardManager/KeyboardManager.swift
@@ -181,18 +181,19 @@ open func bind(inputAccessoryView: UIView, withAdditionalBottomSpace additionalB
         else { return }
 
         let keyboardHeight = notification.endFrame.height
+        let initialBottomGap = self?.bottomGap ?? 0
         let animateAlongside = {
             self?.animateAlongside(notification) {
-                self?.constraints?.bottom?.constant = min(0, -keyboardHeight + (self?.bottomGap ?? 0)) - (additionalBottomSpace?() ?? 0)
+                self?.constraints?.bottom?.constant = min(0, -keyboardHeight + initialBottomGap) - (additionalBottomSpace?() ?? 0)
                 self?.inputAccessoryView?.superview?.layoutIfNeeded()
             }
         }
         animateAlongside()
-        
-        // Doing it a second time delayed is required for accurate placement when using pagesheet on portrait iPad
+
+        // Trigger a new animation if gap changed, this typically happens when using pagesheet on portrait iPad
         DispatchQueue.main.async {
-            let bottomGap = self?.bottomGap ?? 0
-            if bottomGap != 0 {
+            let newBottomGap = self?.bottomGap ?? 0
+            if newBottomGap != 0 && newBottomGap != initialBottomGap {
                 animateAlongside()
             }
         }
@@ -205,18 +206,19 @@ open func bind(inputAccessoryView: UIView, withAdditionalBottomSpace additionalB
         else {
             return
         }
+        let initialBottomGap = self?.bottomGap ?? 0
         let animateAlongside = {
             self?.animateAlongside(notification) {
-                self?.constraints?.bottom?.constant = min(0, -keyboardHeight + (self?.bottomGap ?? 0)) - (additionalBottomSpace?() ?? 0)
+                self?.constraints?.bottom?.constant = min(0, -keyboardHeight + initialBottomGap) - (additionalBottomSpace?() ?? 0)
                 self?.inputAccessoryView?.superview?.layoutIfNeeded()
             }
         }
         animateAlongside()
         
-        // Doing it a second time delayed is required for accurate placement when using pagesheet on portrait iPad
+        // Trigger a new animation if gap changed, this typically happens when using pagesheet on portrait iPad
         DispatchQueue.main.async {
-            let bottomGap = self?.bottomGap ?? 0
-            if bottomGap != 0 && !(self?.justDidWillHide ?? false) {
+            let newBottomGap = self?.bottomGap ?? 0
+            if newBottomGap != 0 && newBottomGap != initialBottomGap && !(self?.justDidWillHide ?? false) {
                 animateAlongside()
             }
         }
@@ -224,18 +226,12 @@ open func bind(inputAccessoryView: UIView, withAdditionalBottomSpace additionalB
     callbacks[.willHide] = { [weak self] (notification) in
         guard notification.isForCurrentApp else { return }
         self?.justDidWillHide = true
-        let animateAlongside = {
-            self?.animateAlongside(notification) { [weak self] in
-                self?.constraints?.bottom?.constant = self?.additionalInputViewBottomConstraintConstant() ?? 0
-                self?.inputAccessoryView?.superview?.layoutIfNeeded()
-            }
+        self?.animateAlongside(notification) { [weak self] in
+            self?.constraints?.bottom?.constant = self?.additionalInputViewBottomConstraintConstant() ?? 0
+            self?.inputAccessoryView?.superview?.layoutIfNeeded()
         }
-        animateAlongside()
-        
-        // Doing it a second time delayed is required for accurate placement when using pagesheet on portrait iPad
         DispatchQueue.main.async {
             self?.justDidWillHide = false
-            animateAlongside()
         }
     }
     return self

--- a/Sources/KeyboardManager/KeyboardManager.swift
+++ b/Sources/KeyboardManager/KeyboardManager.swift
@@ -71,6 +71,9 @@ open class KeyboardManager: NSObject, UIGestureRecognizerDelegate {
     /// A cached notification used as a starting point when a user dragging the `scrollView` down
     /// to interactively dismiss the keyboard
     private var cachedNotification: KeyboardNotification?
+    
+    /// Used to fix a glitch that would otherwise occur when using pagesheets on iPad in iOS 14
+    private var justDidWillHide = false
 
     // MARK: - Initialization
 
@@ -139,6 +142,15 @@ open class KeyboardManager: NSObject, UIGestureRecognizerDelegate {
         callbacks[event] = callback
         return self
     }
+    
+    /// When e.g. using pagesheets on iPad the inputAccessoryView is not stuck to the bottom of the screen.
+    /// This value represents the size of the gap between the bottom of the screen and the bottom of the inputAccessoryView.
+    private var bottomGap: CGFloat {
+        if let inputAccessoryView = inputAccessoryView, let window = inputAccessoryView.window, let superView = inputAccessoryView.superview {
+            return window.frame.height - superView.convert(superView.frame, to: window).maxY
+        }
+        return 0
+    }
 
     /// Constrains the `inputAccessoryView` to the bottom of its superview and sets the
     /// `.willChangeFrame` and `.willHide` event callbacks such that it mimics an `InputAccessoryView`
@@ -146,55 +158,88 @@ open class KeyboardManager: NSObject, UIGestureRecognizerDelegate {
     ///
     /// - Parameter inputAccessoryView: The view to bind to the top of the keyboard but within its superview
     /// - Returns: Self
-    @discardableResult
-    open func bind(inputAccessoryView: UIView, withAdditionalBottomSpace additionalBottomSpace: (() -> CGFloat)? = .none) -> Self {
+@discardableResult
+open func bind(inputAccessoryView: UIView, withAdditionalBottomSpace additionalBottomSpace: (() -> CGFloat)? = .none) -> Self {
 
-        guard let superview = inputAccessoryView.superview else {
-            fatalError("`inputAccessoryView` must have a superview")
+    guard let superview = inputAccessoryView.superview else {
+        fatalError("`inputAccessoryView` must have a superview")
+    }
+    self.inputAccessoryView = inputAccessoryView
+    self.additionalBottomSpace = additionalBottomSpace
+    inputAccessoryView.translatesAutoresizingMaskIntoConstraints = false
+    constraints = NSLayoutConstraintSet(
+        bottom: inputAccessoryView.bottomAnchor.constraint(equalTo: superview.bottomAnchor, constant: additionalInputViewBottomConstraintConstant()),
+        left: inputAccessoryView.leftAnchor.constraint(equalTo: superview.leftAnchor),
+        right: inputAccessoryView.rightAnchor.constraint(equalTo: superview.rightAnchor)
+    ).activate()
+
+    callbacks[.willShow] = { [weak self] (notification) in
+        guard
+            self?.isKeyboardHidden == false,
+            self?.constraints?.bottom?.constant == self?.additionalInputViewBottomConstraintConstant(),
+            notification.isForCurrentApp
+        else { return }
+
+        let keyboardHeight = notification.endFrame.height
+        self?.animateAlongside(notification) {
+            self?.constraints?.bottom?.constant = min(0, -keyboardHeight + (self?.bottomGap ?? 0)) - (additionalBottomSpace?() ?? 0)
+            self?.inputAccessoryView?.superview?.layoutIfNeeded()
         }
-        self.inputAccessoryView = inputAccessoryView
-        self.additionalBottomSpace = additionalBottomSpace
-        inputAccessoryView.translatesAutoresizingMaskIntoConstraints = false
-        constraints = NSLayoutConstraintSet(
-            bottom: inputAccessoryView.bottomAnchor.constraint(equalTo: superview.bottomAnchor, constant: additionalInputViewBottomConstraintConstant()),
-            left: inputAccessoryView.leftAnchor.constraint(equalTo: superview.leftAnchor),
-            right: inputAccessoryView.rightAnchor.constraint(equalTo: superview.rightAnchor)
-        ).activate()
-
-        callbacks[.willShow] = { [weak self] (notification) in
-            guard
-                self?.isKeyboardHidden == false,
-                self?.constraints?.bottom?.constant == self?.additionalInputViewBottomConstraintConstant(),
-                notification.isForCurrentApp
-            else { return }
-
-            let keyboardHeight = notification.endFrame.height
-            self?.animateAlongside(notification) {
-                self?.constraints?.bottom?.constant = -keyboardHeight - (additionalBottomSpace?() ?? 0)
-                self?.inputAccessoryView?.superview?.layoutIfNeeded()
+        
+        // Doing it a second time delayed is required for accurate placement
+        DispatchQueue.main.async {
+            let bottomGap = self?.bottomGap ?? 0
+            if bottomGap != 0 {
+                self?.animateAlongside(notification) {
+                    self?.constraints?.bottom?.constant = min(0, -keyboardHeight + bottomGap) - (additionalBottomSpace?() ?? 0)
+                    self?.inputAccessoryView?.superview?.layoutIfNeeded()
+                }
             }
         }
-        callbacks[.willChangeFrame] = { [weak self] (notification) in
-            let keyboardHeight = notification.endFrame.height
-            guard
-                self?.isKeyboardHidden == false,
-                notification.isForCurrentApp
-            else { return }
-
-            self?.animateAlongside(notification) {
-                self?.constraints?.bottom?.constant = -keyboardHeight - (additionalBottomSpace?() ?? 0)
-                self?.inputAccessoryView?.superview?.layoutIfNeeded()
+    }
+    callbacks[.willChangeFrame] = { [weak self] (notification) in
+        let keyboardHeight = notification.endFrame.height
+        guard
+            self?.isKeyboardHidden == false,
+            notification.isForCurrentApp
+        else {
+            return
+        }
+        self?.animateAlongside(notification) {
+            self?.constraints?.bottom?.constant = min(0, -keyboardHeight + (self?.bottomGap ?? 0)) - (additionalBottomSpace?() ?? 0)
+            self?.inputAccessoryView?.superview?.layoutIfNeeded()
+        }
+        
+        // Doing it a second time delayed is required for accurate placement
+        DispatchQueue.main.async {
+            let bottomGap = self?.bottomGap ?? 0
+            if bottomGap != 0 && !(self?.justDidWillHide ?? false) {
+                self?.animateAlongside(notification) {
+                    self?.constraints?.bottom?.constant = min(0, -keyboardHeight + bottomGap) - (additionalBottomSpace?() ?? 0)
+                    self?.inputAccessoryView?.superview?.layoutIfNeeded()
+                }
             }
         }
-        callbacks[.willHide] = { [weak self] (notification) in
-            guard notification.isForCurrentApp else { return }
+    }
+    callbacks[.willHide] = { [weak self] (notification) in
+        guard notification.isForCurrentApp else { return }
+        self?.justDidWillHide = true
+        self?.animateAlongside(notification) { [weak self] in
+            self?.constraints?.bottom?.constant = self?.additionalInputViewBottomConstraintConstant() ?? 0
+            self?.inputAccessoryView?.superview?.layoutIfNeeded()
+        }
+        
+        // Doing it a second time delayed is required for accurate placement
+        DispatchQueue.main.async {
+            self?.justDidWillHide = false
             self?.animateAlongside(notification) { [weak self] in
                 self?.constraints?.bottom?.constant = self?.additionalInputViewBottomConstraintConstant() ?? 0
                 self?.inputAccessoryView?.superview?.layoutIfNeeded()
             }
         }
-        return self
     }
+    return self
+}
 
     /// Adds a `UIPanGestureRecognizer` to the `scrollView` to enable interactive dismissal`
     ///
@@ -312,7 +357,7 @@ open class KeyboardManager: NSObject, UIGestureRecognizerDelegate {
         frame.size.height = window.bounds.height - frame.origin.y
         keyboardNotification.endFrame = frame
 
-        var yCoordinateDirectlyAboveKeyboard = -frame.height
+        var yCoordinateDirectlyAboveKeyboard = -frame.height + bottomGap
         if shouldApplyAdditionBottomSpaceToInteractiveDismissal, let additionalBottomSpace = additionalBottomSpace {
             yCoordinateDirectlyAboveKeyboard -= additionalBottomSpace()
         }

--- a/Sources/KeyboardManager/KeyboardManager.swift
+++ b/Sources/KeyboardManager/KeyboardManager.swift
@@ -181,16 +181,16 @@ open func bind(inputAccessoryView: UIView, withAdditionalBottomSpace additionalB
         else { return }
 
         let keyboardHeight = notification.endFrame.height
-        let initialBottomGap = self?.bottomGap ?? 0
         let animateAlongside = {
             self?.animateAlongside(notification) {
-                self?.constraints?.bottom?.constant = min(0, -keyboardHeight + initialBottomGap) - (additionalBottomSpace?() ?? 0)
+                self?.constraints?.bottom?.constant = min(0, -keyboardHeight + (self?.bottomGap ?? 0)) - (additionalBottomSpace?() ?? 0)
                 self?.inputAccessoryView?.superview?.layoutIfNeeded()
             }
         }
         animateAlongside()
 
         // Trigger a new animation if gap changed, this typically happens when using pagesheet on portrait iPad
+        let initialBottomGap = self?.bottomGap ?? 0
         DispatchQueue.main.async {
             let newBottomGap = self?.bottomGap ?? 0
             if newBottomGap != 0 && newBottomGap != initialBottomGap {
@@ -206,16 +206,16 @@ open func bind(inputAccessoryView: UIView, withAdditionalBottomSpace additionalB
         else {
             return
         }
-        let initialBottomGap = self?.bottomGap ?? 0
         let animateAlongside = {
             self?.animateAlongside(notification) {
-                self?.constraints?.bottom?.constant = min(0, -keyboardHeight + initialBottomGap) - (additionalBottomSpace?() ?? 0)
+                self?.constraints?.bottom?.constant = min(0, -keyboardHeight + (self?.bottomGap ?? 0)) - (additionalBottomSpace?() ?? 0)
                 self?.inputAccessoryView?.superview?.layoutIfNeeded()
             }
         }
         animateAlongside()
         
         // Trigger a new animation if gap changed, this typically happens when using pagesheet on portrait iPad
+        let initialBottomGap = self?.bottomGap ?? 0
         DispatchQueue.main.async {
             let newBottomGap = self?.bottomGap ?? 0
             if newBottomGap != 0 && newBottomGap != initialBottomGap && !(self?.justDidWillHide ?? false) {


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This fixes layout (gap) issues when keyboard appears on iPad when VC is presented as pagesheet of formsheet.

Does this close any currently open issues?
------------------------------------------
Closes #238

Any relevant logs, error output, etc?
-------------------------------------
none

Any other comments?
-------------------
The fixes are a bit hacky but it's the only way I could find that works.

Where has this been tested?
---------------------------
**Devices/Simulators:** 
iPad with and without home button, landscape and portrait (important). Also tested on various iPhones to make sure it kept working fine there too.

**iOS Version:** 
14/15/16

**Swift Version:** 
the one used by Xcode 14.3

**InputBarAccessoryView Version:** 
6.2.0


