### PR TITLE
bug: Fixed library crash after adding image attachment #237

### DIFF
--- a/Sources/Plugins/AttachmentManager/AttachmentManager.swift
+++ b/Sources/Plugins/AttachmentManager/AttachmentManager.swift
@@ -202,17 +202,17 @@ extension AttachmentManager: UICollectionViewDataSource, UICollectionViewDelegat
     
     final public func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
         
-		var height = attachmentView.intrinsicContentHeight
-		if let layout = collectionView.collectionViewLayout as? UICollectionViewFlowLayout {
-			height -= (layout.sectionInset.bottom + layout.sectionInset.top + collectionView.contentInset.top + collectionView.contentInset.bottom)
-		}
-		
-		// Prevent out of range error when the AttachmentCell has not been added the attachment array
-		if indexPath.row == attachments.count && showAddAttachmentCell {
-			return CGSize(width: height, height: height)
-		}
-		
-		let attachment = self.attachments[indexPath.row]
+        var height = attachmentView.intrinsicContentHeight
+        if let layout = collectionView.collectionViewLayout as? UICollectionViewFlowLayout {
+            height -= (layout.sectionInset.bottom + layout.sectionInset.top + collectionView.contentInset.top + collectionView.contentInset.bottom)
+        }
+        
+        // Prevent out of range error when the AttachmentCell has not been added the attachment array
+        if indexPath.row == attachments.count && showAddAttachmentCell {
+            return CGSize(width: height, height: height)
+        }
+        
+        let attachment = self.attachments[indexPath.row]
         if let customSize = self.dataSource?.attachmentManager(self, sizeFor: attachment, at: indexPath.row){
             return customSize
         }

--- a/Sources/Plugins/AttachmentManager/AttachmentManager.swift
+++ b/Sources/Plugins/AttachmentManager/AttachmentManager.swift
@@ -202,9 +202,14 @@ extension AttachmentManager: UICollectionViewDataSource, UICollectionViewDelegat
     
     final public func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
         
-		// Prevent out of range error when the attachments cell has not been added the attachment array
+		var height = attachmentView.intrinsicContentHeight
+		if let layout = collectionView.collectionViewLayout as? UICollectionViewFlowLayout {
+			height -= (layout.sectionInset.bottom + layout.sectionInset.top + collectionView.contentInset.top + collectionView.contentInset.bottom)
+		}
+		
+		// Prevent out of range error when the AttachmentCell has not been added the attachment array
 		if indexPath.row == attachments.count && showAddAttachmentCell {
-			return .zero
+			return CGSize(width: height, height: height)
 		}
 		
 		let attachment = self.attachments[indexPath.row]
@@ -212,10 +217,6 @@ extension AttachmentManager: UICollectionViewDataSource, UICollectionViewDelegat
             return customSize
         }
         
-        var height = attachmentView.intrinsicContentHeight
-        if let layout = collectionView.collectionViewLayout as? UICollectionViewFlowLayout {
-            height -= (layout.sectionInset.bottom + layout.sectionInset.top + collectionView.contentInset.top + collectionView.contentInset.bottom)
-        }
         return CGSize(width: height, height: height)
     }
     

--- a/Sources/Plugins/AttachmentManager/AttachmentManager.swift
+++ b/Sources/Plugins/AttachmentManager/AttachmentManager.swift
@@ -202,7 +202,13 @@ extension AttachmentManager: UICollectionViewDataSource, UICollectionViewDelegat
     
     final public func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
         
-        if let customSize = self.dataSource?.attachmentManager(self, sizeFor: self.attachments[indexPath.row], at: indexPath.row){
+		// Prevent out of range error when the attachments cell has not been added the attachment array
+		if indexPath.row == attachments.count && showAddAttachmentCell {
+			return .zero
+		}
+		
+		let attachment = self.attachments[indexPath.row]
+        if let customSize = self.dataSource?.attachmentManager(self, sizeFor: attachment, at: indexPath.row){
             return customSize
         }
         


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Fixes Issue #237 by returning the default cell size if the attachment cell is shown and the indexPath is set to the attachment cell.

Does this close any currently open issues?
------------------------------------------
No

Any relevant logs, error output, etc?
-------------------------------------
Error reported when the example app crashes:
Swift/ContiguousArrayBuffer.swift:600: Fatal error: Index out of range

Where has this been tested?
---------------------------
**Devices/Simulators:** 
iPhone 14 Pro simulator

**iOS Version:** 
iOs 16.4

**Swift Version:** 
5.7

**InputBarAccessoryView Version:** 
6.2.0
