### PR TITLE
Consider custom middleContentView height

### DIFF
--- a/Sources/InputBarAccessoryView.swift
+++ b/Sources/InputBarAccessoryView.swift
@@ -584,7 +584,10 @@ open class InputBarAccessoryView: UIView {
                 inputTextView.invalidateIntrinsicContentSize()
             }
         }
-        
+        if let middleContentView, middleContentView != inputTextView {
+            inputTextViewHeight = middleContentView.intrinsicContentSize.height
+        }
+
         // Calculate the required height
         let totalPadding = padding.top + padding.bottom + topStackViewPadding.top + middleContentViewPadding.top + middleContentViewPadding.bottom
         let topStackViewHeight = topStackView.arrangedSubviews.count > 0 ? topStackView.bounds.height : 0


### PR DESCRIPTION
This fixes #264

I'm not sure if it's a proper fix for the library, but it works good in my case.

I believe the code above the fix is still needed to manage `inputTextView.isScrollEnabled` state with the height constraint, so it shouldn't be placed in `else` statement.

https://github.com/nathantannar4/InputBarAccessoryView/blob/093bdc71dc26bfcdaa71352d5ff0cd84b9b8d427/Sources/InputBarAccessoryView.swift#L571-L586