### PR TITLE
Migrate to Swift 6, fully support async/await and Swift concurrency, drop iOS 13

### DIFF
--- a/.github/workflows/ci_master_framework.yml
+++ b/.github/workflows/ci_master_framework.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   tests:
     name: Build Framework
-    runs-on: macOS-latest
+    runs-on: macOS-15
     steps:
     - name: Checkout the Git repository
       uses: actions/checkout@v4

--- a/.github/workflows/ci_pr_example.yml
+++ b/.github/workflows/ci_pr_example.yml
@@ -5,7 +5,7 @@ on: pull_request
 jobs:
   tests:
     name: Build Example app
-    runs-on: macOS-latest
+    runs-on: macOS-15
     steps:
     - name: Checkout the Git repository
       uses: actions/checkout@v4

--- a/.github/workflows/ci_pr_framework.yml
+++ b/.github/workflows/ci_pr_framework.yml
@@ -5,7 +5,7 @@ on: pull_request
 jobs:
   tests:
     name: Build Framework
-    runs-on: macOS-latest
+    runs-on: macOS-15
     steps:
     - name: Checkout the Git repository
       uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 #  Changelog
 - Master:
    - Nothing yet
+- 7.0.0
+   - [#274](https://github.com/nathantannar4/InputBarAccessoryView/pull/276) Migrate to Swift 6 with full async/Await Swift 6 concurrency support
+   - Drop iOS 13 support
 - 6.5.0
    - Bump Swift version to 5.10
    - [#274](https://github.com/nathantannar4/InputBarAccessoryView/pull/274) Perform layout changes on main thread

--- a/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 52;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -226,8 +226,9 @@
 		383B83911F47897800027965 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				BuildIndependentTargetsInParallel = YES;
 				LastSwiftUpdateCheck = 0830;
-				LastUpgradeCheck = 1230;
+				LastUpgradeCheck = 1600;
 				ORGANIZATIONNAME = "Nathan Tannar";
 				TargetAttributes = {
 					383B83981F47897800027965 = {
@@ -355,7 +356,7 @@
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -410,7 +411,7 @@
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 			};
@@ -422,6 +423,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				DEVELOPMENT_TEAM = JH5XJ55XGZ;
 				INFOPLIST_FILE = Resources/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -438,6 +440,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				DEVELOPMENT_TEAM = JH5XJ55XGZ;
 				INFOPLIST_FILE = Resources/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/Example/Sources/Example ViewControllers/AdditionalBottomSpaceExampleViewController.swift
+++ b/Example/Sources/Example ViewControllers/AdditionalBottomSpaceExampleViewController.swift
@@ -38,7 +38,7 @@ final class AdditionalBottomSpaceExampleViewController: CommonTableViewControlle
 
         keyboardManager.additionalInputViewBottomConstraintConstant = {
             var safeBottomInset: CGFloat = self.view.safeAreaInsets.bottom
-            if let windowBottomInset = UIApplication.shared.windows.first?.safeAreaInsets.bottom,
+            if let windowBottomInset = UIWindowScene.activeScene?.windows.first?.safeAreaInsets.bottom,
                safeBottomInset != windowBottomInset {
                 safeBottomInset = windowBottomInset
             }
@@ -63,5 +63,16 @@ final class AdditionalBottomSpaceExampleViewController: CommonTableViewControlle
         super.viewDidAppear(animated)
 
         self.inputBar.inputTextView.becomeFirstResponder()
+    }
+}
+
+private extension UIWindowScene {
+    static var activeScene: UIWindowScene? {
+        let connectedScenes = UIApplication.shared.connectedScenes
+        if connectedScenes.count > 1 {
+            return connectedScenes.first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene
+        } else {
+            return connectedScenes.first as? UIWindowScene
+        }
     }
 }

--- a/GitHubActions/build.sh
+++ b/GitHubActions/build.sh
@@ -12,13 +12,13 @@ MODE="$1"
 
 if [ "$MODE" = "framework" -o "$MODE" = "all" ]; then
   echo "Building InputBarAccessoryView Framework."
-  set -o pipefail && xcodebuild build -scheme InputBarAccessoryView -sdk iphonesimulator -destination "platform=iOS Simulator,name=iPhone 14" | xcpretty -c
+  set -o pipefail && xcodebuild build -scheme InputBarAccessoryView -sdk iphonesimulator -destination "platform=iOS Simulator,name=iPhone 16" | xcpretty -c
   success="1"
 fi
 
 if [ "$MODE" = "example" -o "$MODE" = "all" ]; then
   echo "Building InputBarAccessoryView Example app."
-  set -o pipefail && xcodebuild build -project Example/Example.xcodeproj -scheme Example -sdk iphonesimulator -destination "platform=iOS Simulator,name=iPhone 14 Pro" | xcpretty -c
+  set -o pipefail && xcodebuild build -project Example/Example.xcodeproj -scheme Example -sdk iphonesimulator -destination "platform=iOS Simulator,name=iPhone 16 Pro" | xcpretty -c
   success="1"
 fi
 

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,10 @@ let package = Package(
         .target(
             name: "InputBarAccessoryView",
             path: "Sources",
-            exclude: ["Supporting/Info.plist"]
+            exclude: ["Supporting/Info.plist"],
+            swiftSettings: [
+                .enableExperimentalFeature("StrictConcurrency")
+            ]
         )
     ],
     swiftLanguageVersions: [.v5]

--- a/Package.swift
+++ b/Package.swift
@@ -1,11 +1,11 @@
-// swift-tools-version:5.10
+// swift-tools-version:6.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
 
 let package = Package(
     name: "InputBarAccessoryView",
-    platforms: [.iOS(.v13)],
+    platforms: [.iOS(.v14)],
     products: [
         .library(name: "InputBarAccessoryView", targets: ["InputBarAccessoryView"]),
     ],
@@ -13,11 +13,8 @@ let package = Package(
         .target(
             name: "InputBarAccessoryView",
             path: "Sources",
-            exclude: ["Supporting/Info.plist"],
-            swiftSettings: [
-                .enableExperimentalFeature("StrictConcurrency")
-            ]
+            exclude: ["Supporting/Info.plist"]
         )
     ],
-    swiftLanguageVersions: [.v5]
+    swiftLanguageModes: [.v6]
 )

--- a/README.md
+++ b/README.md
@@ -32,8 +32,10 @@ https://github.com/nathantannar4/InputBarAccessoryView.git
 
 ### Requirements
 
-iOS 13.0+
-Swift 5.5
+iOS 14.0+
+Swift 6
+
+> The latest iOS 13 release is v6.5.0
 
 > The latest iOS 12 release is v5.5.0
 
@@ -74,6 +76,21 @@ Add your app to the list of apps using this library and make a pull request.
 iMessage style [TypingIndicator](https://github.com/nathantannar4/TypingIndicator) for chat apps
 
 ## Latest Releases
+7.0.0
+   - **Breaking change**: Drop iOS 13 support
+   - **Breaking change**: Move to Swift 6, fully support  Swift concurrency
+
+6.5.0
+   - Bump Swift version to 5.10
+   - Perform layout changes on main thread
+   
+6.4.0
+   - Fixed bottom gap calculations for embedded controllers
+   
+6.3.0
+   - Fixed the gap between keyboard and input bar when used on pagesheet/formsheet on iPad
+   - Fixed crash after adding image attachment
+
 6.2.0
    - Remove `canBecomeFirstResponder` on `InputTextView` to fix `UITextViewDelegate` methods not being called
    
@@ -88,16 +105,6 @@ iMessage style [TypingIndicator](https://github.com/nathantannar4/TypingIndicato
    - **Breaking change**: Drop CocoaPods support & RxSwift extension (it was available only via CocoaPods)
    - KeyboardManager will not update position of inputAccessoryView from interactive dismiss panGesture when the keyboard is floating
    - Update docs
-
-5.5.0
-   - Update SPM tools to Swift 5.5
-   - Added new optional delegate method for custom attachments size
-   - Added new animations for left/right stack view constraints
-
-5.4.0
-   - Make sure framework is ready for Xcode 13
-   - Fix availability in AppExtensions
-   - Fix Package.swift to support iOS 12+ only
     
 See [CHANGELOG](./CHANGELOG.md) for more details and older releases.
 

--- a/Sources/Models/HorizontalEdgePadding.swift
+++ b/Sources/Models/HorizontalEdgePadding.swift
@@ -8,7 +8,7 @@
 
 import CoreGraphics
 
-public struct HorizontalEdgePadding {
+public struct HorizontalEdgePadding: Sendable {
     public let left: CGFloat
     public let right: CGFloat
 

--- a/Sources/Models/NSConstraintLayoutSet.swift
+++ b/Sources/Models/NSConstraintLayoutSet.swift
@@ -28,6 +28,7 @@
 import Foundation
 import UIKit
 
+@MainActor
 class NSLayoutConstraintSet {
     
     var top: NSLayoutConstraint?

--- a/Sources/Plugins/AttachmentManager/AttachmentManager.swift
+++ b/Sources/Plugins/AttachmentManager/AttachmentManager.swift
@@ -27,6 +27,7 @@
 
 import UIKit
 
+@MainActor
 open class AttachmentManager: NSObject, InputPlugin {
     
     public enum Attachment {

--- a/Sources/Plugins/AutocompleteManager/Protocols/AutocompleteManagerDataSource.swift
+++ b/Sources/Plugins/AutocompleteManager/Protocols/AutocompleteManagerDataSource.swift
@@ -28,6 +28,7 @@
 import UIKit
 
 /// AutocompleteManagerDataSource is a protocol that passes data to the AutocompleteManager
+@MainActor
 public protocol AutocompleteManagerDataSource: AnyObject {
     
     /// The autocomplete options for the registered prefix.

--- a/Sources/Protocols/InputBarAccessoryViewDelegate.swift
+++ b/Sources/Protocols/InputBarAccessoryViewDelegate.swift
@@ -29,6 +29,7 @@ import Foundation
 import UIKit
 
 /// InputBarAccessoryViewDelegate is a protocol that can recieve notifications from the InputBarAccessoryView
+@MainActor
 public protocol InputBarAccessoryViewDelegate: AnyObject {
     
     /// Called when the default send button has been selected

--- a/Sources/Protocols/InputItem.swift
+++ b/Sources/Protocols/InputItem.swift
@@ -28,6 +28,7 @@
 import UIKit
 
 /// InputItem is a protocol that links elements to the InputBarAccessoryView to make them reactive
+@MainActor
 public protocol InputItem: AnyObject {
     
     /// A weak reference to the InputBarAccessoryView. Set when inserted into an InputStackView

--- a/Sources/Protocols/InputPlugin.swift
+++ b/Sources/Protocols/InputPlugin.swift
@@ -28,6 +28,7 @@
 import UIKit
 
 /// `InputPlugin` is a protocol that makes integrating plugins to the `InputBarAccessoryView` easy.
+@MainActor
 public protocol InputPlugin: AnyObject {
     
     /// Should reload the state if the `InputPlugin`


### PR DESCRIPTION
- Migrate to Swift 6
- Fully enable Swift concurrency
- Drop iOS 13 - even tho Swift concurrency has been backed-in for iOS 13, it's recommended to use iOS 14+, so I don't see a reason why keeping it around - those users should stick to 6.5.0 release
- Update example project

Fixes https://github.com/nathantannar4/InputBarAccessoryView/issues/273